### PR TITLE
Add domain component

### DIFF
--- a/aif_gen/task/__init__.py
+++ b/aif_gen/task/__init__.py
@@ -1,2 +1,3 @@
 from aif_gen.task.alignment_task import AlignmentTask
 from aif_gen.task.domain import Domain
+from aif_gen.task.domain_component import DomainComponent

--- a/aif_gen/task/alignment_task.py
+++ b/aif_gen/task/alignment_task.py
@@ -19,6 +19,21 @@ class AlignmentTask:
 
     @classmethod
     def from_dict(cls, task_dict: Dict[str, Any]) -> 'AlignmentTask':
+        r"""Construct an AlignmentTask from dictionary represenetation.
+
+        Note:
+            Expects 'domain', 'objective', and 'preference' keys to be present in the dictionary.
+            Moreover, expects that the 'domain' value is parasable by Domain.from_dict().
+
+        Args:
+            task_dict (Dict[str, Any]): The dictionary that encodes the AlignmentTask.
+
+        Returns:
+            AlignmentTask: The newly constructed alignmentTask
+
+        Raises:
+            ValueError: If the input dictionary is missing any required keys.
+        """
         expected_keys = {'domain', 'objective', 'preference'}
         missing_keys = expected_keys - set(task_dict)
         if len(missing_keys):
@@ -29,17 +44,34 @@ class AlignmentTask:
         preference = task_dict['preference']
         return cls(domain, objective, preference)
 
+    def to_dict(self) -> Dict[str, Any]:
+        r"""Convert the AlignmentTask to dictionary represenetation.
+
+        Note: This method is the functional inverse of AlignmentTask.from_dict().
+
+        Returns:
+            Dict[str, Any]: The dictionary representation of the alignmentTask.
+        """
+        return {
+            'domain': self.domain.to_dict(),
+            'objective': self.objective,
+            'preference': self.preference,
+        }
+
     def __str__(self) -> str:
         return f'AlignmentTask({self.domain}, Objective: {self.objective}, Preference: {self.preference})'
 
     @property
     def domain(self) -> Domain:
+        """Domain: The domain in the current AlignmentTask."""
         return self._domain
 
     @property
     def objective(self) -> str:
+        """str: The objective in the current AlignmentTask."""
         return self._objective
 
     @property
     def preference(self) -> str:
+        """str: The preference in the current AlignmentTask."""
         return self._preference

--- a/aif_gen/task/domain.py
+++ b/aif_gen/task/domain.py
@@ -26,6 +26,11 @@ class Domain:
             raise ValueError(
                 f'Number of components and weights must match, but got {len(components)} components and {len(weights)} weights'
             )
+        for i, weight in enumerate(weights):
+            if weight < 0:
+                raise ValueError(
+                    f'Got a negative weight for component: {components[i]}'
+                )
 
         self._components = components
         self._weights = weights

--- a/aif_gen/task/domain.py
+++ b/aif_gen/task/domain.py
@@ -6,9 +6,16 @@ from .domain_component import DomainComponent
 class Domain:
     r"""A domain is a combination of DomainComponents along with a weight for each component.
 
+    Note: We do not enforce that the weights be normalized.
+
     Args:
         components (List[DomainComponent]): List of DomainComponents that constitute the domain.
         weights (Optional[List[float]]): Weights given to each constituent component (uniform if not specified).
+
+    Raises:
+        ValueError: If the list of components is empty.
+        ValueError: If the number of weights matches the number of components.
+        ValueError: If any of the provided weights are negative.
     """
 
     def __init__(
@@ -37,6 +44,26 @@ class Domain:
 
     @classmethod
     def from_dict(cls, domain_dict: Dict[str, Dict[str, Any]]) -> 'Domain':
+        r"""Construct an Domain from dictionary represenetation.
+
+        Note:
+            Expects each key to denote the 'name' of a DomainComponent, and each value
+            to be a dictionary that is parsable by DomainComponent.from_dict().
+
+            Moreover, each value should include a ('weight': weight_value: float) key-value
+            pair that encodes the weight for that given DomainComponent.
+
+            If these 'weight' keys are no present, the uniform weight initialization is used.
+
+        Args:
+            domain_dict(Dict[str, Dict[str, Any]]): The dictionary that encodes the Domain.
+
+        Returns:
+            Domain: The newly constructed Domain.
+
+        Raises:
+            ValueError: If the input dictionary is missing any required keys.
+        """
         components, component_weights = [], []
         for component_name, component_args in domain_dict.items():
             component_args['name'] = component_name
@@ -48,6 +75,20 @@ class Domain:
         weights = None if not len(component_weights) else component_weights
         return cls(components, weights)
 
+    def to_dict(self) -> Dict[str, Any]:
+        r"""Convert the Domain to dictionary represenetation.
+
+        Note: This method is the functional inverse of Domain.from_dict().
+
+        Returns:
+            Dict[str, Any]: The dictionary representation of the Domain.
+        """
+        domain_dict = {}
+        for i in range(self.num_components):
+            domain_dict[self.components[i].name] = self.components[i].to_dict()
+            domain_dict[self.components[i].name]['weight'] = self.weights[i]
+        return domain_dict
+
     def __str__(self) -> str:
         s = f'Domain: ['
         for i in range(self.num_components):
@@ -57,12 +98,15 @@ class Domain:
 
     @property
     def components(self) -> List[DomainComponent]:
+        """List[DomainComponent]: The list of components associated with this Domain."""
         return self._components
 
     @property
     def num_components(self) -> int:
+        """int: The number of components associated with this Domain."""
         return len(self.components)
 
     @property
     def weights(self) -> List[float]:
+        """List[float]: The weights associated with this Domain."""
         return self._weights

--- a/aif_gen/task/domain.py
+++ b/aif_gen/task/domain.py
@@ -1,17 +1,63 @@
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
+
+from .domain_component import DomainComponent
 
 
 class Domain:
-    def __init__(self, domain: str) -> None:
-        self._domain = domain
+    r"""A domain is a combination of DomainComponents along with a weight for each component.
+
+    Args:
+        components (List[DomainComponent]): List of DomainComponents that constitute the domain.
+        weights (Optional[List[float]]): Weights given to each constituent component (uniform if not specified).
+    """
+
+    def __init__(
+        self, components: List[DomainComponent], weights: Optional[List[float]] = None
+    ) -> None:
+        if not len(components):
+            raise ValueError(
+                'Cannot initialize a Domain with an empty list of DomainComponents'
+            )
+
+        if weights is None:
+            weights = [1 / len(components)] * len(components)
+
+        if len(weights) != len(components):
+            raise ValueError(
+                f'Number of components and weights must match, but got {len(components)} components and {len(weights)} weights'
+            )
+
+        self._components = components
+        self._weights = weights
 
     @classmethod
-    def from_dict(cls, domain_dict: Dict[str, Any]) -> 'Domain':
-        return cls('Mock Domain')
+    def from_dict(cls, domain_dict: Dict[str, Dict[str, Any]]) -> 'Domain':
+        components, component_weights = [], []
+        for component_name, component_args in domain_dict.items():
+            component_args['name'] = component_name
+            components.append(DomainComponent.from_dict(component_args))
+
+            if 'weight' in component_args:
+                component_weights.append(component_args['weight'])
+
+        weights = None if not len(component_weights) else component_weights
+        return cls(components, weights)
 
     def __str__(self) -> str:
-        return f'Domain: {self._domain}'
+        s = f'Domain: ['
+        for i in range(self.num_components):
+            s += f'({self.components[i]}, weight={self.weights[i]:.2f}), '
+        s += ']'
+        return s
 
     @property
-    def domain(self) -> str:
-        return self._domain
+    def components(self) -> List[DomainComponent]:
+        return self._components
+
+    @property
+    def num_components(self) -> int:
+        return len(self.components)
+
+    @property
+    def weights(self) -> List[float]:
+        return self._weights

--- a/aif_gen/task/domain_component.py
+++ b/aif_gen/task/domain_component.py
@@ -1,0 +1,55 @@
+from typing import List, Optional
+
+
+class DomainComponent:
+    r"""A domain component is an alias for a set of 'seed words' that describe a
+    specific sphere of activity or knowledge.
+
+    Args:
+        name (str): The name that describes the content of the domain component.
+        seed_words (List[str]): The list of seed words that describe the domain component.
+        description (Optional[str]): An optional description of the domain component.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        seed_words: List[str],
+        description: Optional[str] = None,
+    ) -> None:
+        if not len(seed_words):
+            raise ValueError(
+                'Cannot initialize a DomainComponent with an empty list of seed words'
+            )
+
+        self._name = name
+        self._seed_words = seed_words
+        self._description = description
+
+    def __str__(self) -> str:
+        s = f'{self._name} '
+        if self.description is not None:
+            s += f'({self.description}) '
+
+        if len(self.seed_words) > 3:
+            s += str(self._seed_words[:3])[:-1] + ', ...]'
+        else:
+            s += str(self._seed_words)
+
+        return s
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def seed_words(self) -> List[str]:
+        return self._seed_words
+
+    @property
+    def num_seed_words(self) -> int:
+        return len(self.seed_words)
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._description

--- a/aif_gen/task/domain_component.py
+++ b/aif_gen/task/domain_component.py
@@ -9,6 +9,9 @@ class DomainComponent:
         name (str): The name that describes the content of the domain component.
         seed_words (List[str]): The list of seed words that describe the domain component.
         description (Optional[str]): An optional description of the domain component.
+
+    Raises:
+        ValueError: If no seed words are provided.
     """
 
     def __init__(
@@ -28,6 +31,20 @@ class DomainComponent:
 
     @classmethod
     def from_dict(cls, component_dict: Dict[str, Any]) -> 'DomainComponent':
+        r"""Construct an AlignmentTask from dictionary represenetation.
+
+        Note:
+            Expects 'name', and 'seed_words' keys to be present in the dictionary.
+
+        Args:
+            component_dict(Dict[str, Any]): The dictionary that encodes the DomainComponent.
+
+        Returns:
+            DomainComponent: The newly constructed DomainComponent.
+
+        Raises:
+            ValueError: If the input dictionary is missing any required keys.
+        """
         expected_keys = {'name', 'seed_words'}
         missing_keys = expected_keys - set(component_dict)
         if len(missing_keys):
@@ -38,11 +55,25 @@ class DomainComponent:
         description = component_dict.get('description')
         return cls(name, seed_words, description)
 
+    def to_dict(self) -> Dict[str, Any]:
+        r"""Convert the DomainComponent to dictionary represenetation.
+
+        Note: This method is the functional inverse of DomainComponent.from_dict().
+
+        Returns:
+            Dict[str, Any]: The dictionary representation of the DomainComponent.
+        """
+        component_dict = {'name': self.name, 'seed_words': self.seed_words}
+        if self.description is not None:
+            component_dict['description'] = self.description
+        return component_dict
+
     def __str__(self) -> str:
         s = f'{self._name} '
         if self.description is not None:
             s += f'({self.description}) '
 
+        # Truncate number of seed words to first 3 to avoid spamming output stream
         if len(self.seed_words) > 3:
             s += str(self._seed_words[:3])[:-1] + ', ...]'
         else:
@@ -52,16 +83,20 @@ class DomainComponent:
 
     @property
     def name(self) -> str:
+        """str: The name of this DomainComponent."""
         return self._name
 
     @property
     def seed_words(self) -> List[str]:
+        """List[str]: The list of seed words aliased by this DomainComponent."""
         return self._seed_words
 
     @property
     def num_seed_words(self) -> int:
+        """int: The number of seed words aliased by this DomainComponent."""
         return len(self.seed_words)
 
     @property
     def description(self) -> Optional[str]:
+        """Optional[str]: The description in the current DomainComponent, if it exists."""
         return self._description

--- a/aif_gen/task/domain_component.py
+++ b/aif_gen/task/domain_component.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 
 class DomainComponent:
@@ -25,6 +25,18 @@ class DomainComponent:
         self._name = name
         self._seed_words = seed_words
         self._description = description
+
+    @classmethod
+    def from_dict(cls, component_dict: Dict[str, Any]) -> 'DomainComponent':
+        expected_keys = {'name', 'seed_words'}
+        missing_keys = expected_keys - set(component_dict)
+        if len(missing_keys):
+            raise ValueError(f'Missing required keys: {missing_keys}')
+
+        name = component_dict['name']
+        seed_words = component_dict['seed_words']
+        description = component_dict.get('description')
+        return cls(name, seed_words, description)
 
     def __str__(self) -> str:
         s = f'{self._name} '

--- a/test/test_alignment_task.py
+++ b/test/test_alignment_task.py
@@ -53,3 +53,52 @@ def test_init_from_dict_missing_keys():
 
     with pytest.raises(ValueError):
         _ = AlignmentTask.from_dict(task_dict)
+
+
+def test_to_dict_no_weights():
+    task_dict = {
+        'domain': {
+            'Component A': {
+                'seed_words': ['a_foo', 'a_bar', 'a_baz'],
+                'description': 'A Mock Domain Component',
+            },
+            'Component B': {
+                'seed_words': ['b_foo', 'b_bar', 'b_baz'],
+                'description': 'B Mock Domain Component',
+            },
+        },
+        'objective': 'Mock Objective',
+        'preference': 'Mock Preference',
+    }
+
+    # Note: We automatically add uniform weights to the domain if they were not specified
+    expected_dict = task_dict
+    expected_dict['domain']['Component A']['weight'] = 0.5
+    expected_dict['domain']['Component B']['weight'] = 0.5
+
+    task = AlignmentTask.from_dict(task_dict)
+    assert expected_dict == task.to_dict()
+
+
+def test_to_dict_with_weights():
+    task_dict = {
+        'domain': {
+            'Component A': {
+                'weight': 0.3,
+                'seed_words': ['a_foo', 'a_bar', 'a_baz'],
+                'description': 'A Mock Domain Component',
+            },
+            'Component B': {
+                'weight': 0.7,
+                'seed_words': ['b_foo', 'b_bar', 'b_baz'],
+                'description': 'B Mock Domain Component',
+            },
+        },
+        'objective': 'Mock Objective',
+        'preference': 'Mock Preference',
+    }
+
+    expected_dict = task_dict
+
+    task = AlignmentTask.from_dict(task_dict)
+    assert expected_dict == task.to_dict()

--- a/test/test_alignment_task.py
+++ b/test/test_alignment_task.py
@@ -4,31 +4,51 @@ from aif_gen.task import AlignmentTask, Domain
 
 
 def test_init():
-    domain = Domain('Mock Domain')
+    component_dict = {
+        'Component A': {
+            'seed_words': ['a_foo', 'a_bar', 'a_baz'],
+            'description': 'A Mock Domain Component',
+        },
+        'Component B': {
+            'seed_words': ['b_foo', 'b_bar', 'b_baz'],
+            'description': 'B Mock Domain Component',
+        },
+    }
+    domain = Domain.from_dict(component_dict)
     objective = 'Mock Objective'
     preference = 'Mock Preference'
 
     task = AlignmentTask(domain, objective, preference)
-    exp_str = 'AlignmentTask(Domain: Mock Domain, Objective: Mock Objective, Preference: Mock Preference)'
+    exp_str = f'AlignmentTask({str(domain)}, Objective: Mock Objective, Preference: Mock Preference)'
     assert str(task) == exp_str
 
 
 def test_init_from_dict():
     task_dict = {
-        'domain': 'Mock Domain',
+        'domain': {
+            'Component A': {
+                'seed_words': ['a_foo', 'a_bar', 'a_baz'],
+                'description': 'A Mock Domain Component',
+            },
+            'Component B': {
+                'seed_words': ['b_foo', 'b_bar', 'b_baz'],
+                'description': 'B Mock Domain Component',
+            },
+        },
         'objective': 'Mock Objective',
         'preference': 'Mock Preference',
     }
 
     task = AlignmentTask.from_dict(task_dict)
-    exp_str = 'AlignmentTask(Domain: Mock Domain, Objective: Mock Objective, Preference: Mock Preference)'
+    domain = Domain.from_dict(task_dict['domain'])
+    exp_str = f'AlignmentTask({str(domain)}, Objective: Mock Objective, Preference: Mock Preference)'
     assert str(task) == exp_str
 
 
 def test_init_from_dict_missing_keys():
-    task_dict = {  # Missing 'preference' key
-        'domain': 'Mock Domain',
+    task_dict = {  # Missing 'domain' key
         'objective': 'Mock Objective',
+        'preference': 'Mock Preference',
     }
 
     with pytest.raises(ValueError):

--- a/test/test_domain.py
+++ b/test/test_domain.py
@@ -132,3 +132,65 @@ def test_init_from_dict_no_weights():
         assert component_dict[component.name]['seed_words'] == component.seed_words
         assert component_dict[component.name]['description'] == component.description
     assert domain.weights == [1 / len(component_dict)] * len(component_dict)
+
+
+def test_to_dict_no_weights():
+    component_dict = {
+        'Component A': {
+            'seed_words': ['a_foo', 'a_bar', 'a_baz'],
+            'description': 'A Mock Domain Component',
+        },
+        'Component B': {
+            'seed_words': ['b_foo', 'b_bar', 'b_baz'],
+            'description': 'B Mock Domain Component',
+        },
+        'Component C': {
+            'seed_words': ['c_foo', 'c_bar', 'c_baz'],
+            'description': 'C Mock Domain Component',
+        },
+    }
+
+    domain = Domain.from_dict(component_dict)
+
+    # Note: We automatically add uniform weights to the domain if they were not specified
+    expected_dict = component_dict
+    expected_dict['Component A']['weight'] = 1 / 3
+    expected_dict['Component B']['weight'] = 1 / 3
+    expected_dict['Component C']['weight'] = 1 / 3
+    assert expected_dict == domain.to_dict()
+
+
+def test_to_dict_with_weights():
+    component_dict = {
+        'Component A': {
+            'seed_words': ['a_foo', 'a_bar', 'a_baz'],
+            'description': 'A Mock Domain Component',
+            'weight': 1.5,
+        },
+        'Component B': {
+            'seed_words': ['b_foo', 'b_bar', 'b_baz'],
+            'description': 'B Mock Domain Component',
+            'weight': 0.7,
+        },
+        'Component C': {
+            'seed_words': ['c_foo', 'c_bar', 'c_baz'],
+            'description': 'C Mock Domain Component',
+            'weight': 0.3,
+        },
+    }
+
+    components, weights = [], []
+    for component_name, component_args in component_dict.items():
+        components.append(
+            DomainComponent(
+                component_name,
+                component_args['seed_words'],
+                component_args['description'],
+            )
+        )
+        weights.append(component_args['weight'])
+
+    domain = Domain.from_dict(component_dict)
+
+    expected_dict = component_dict
+    assert expected_dict == domain.to_dict()

--- a/test/test_domain.py
+++ b/test/test_domain.py
@@ -1,6 +1,123 @@
 import pytest
 
+from aif_gen.task import Domain, DomainComponent
 
-@pytest.mark.skip(reason='Not implemented')
+
 def test_init():
-    pass
+    component_a = DomainComponent('Component A', ['a_foo', 'a_bar', 'a_baz'])
+    component_b = DomainComponent('Component B', ['b_foo', 'b_bar'])
+    component_c = DomainComponent('Component C', ['c_foo', 'c_bar', 'c_baz', 'c_bat'])
+
+    components = [component_a, component_b, component_c]
+    weights = [1.5, 0.7, 0.3]  # Need not be normalized
+
+    domain = Domain(components, weights)
+    assert domain.components == components
+    assert domain.num_components == len(components)
+    assert domain.weights == weights
+
+
+def test_init_no_weights():
+    component_a = DomainComponent('Component A', ['a_foo', 'a_bar', 'a_baz'])
+    component_b = DomainComponent('Component B', ['b_foo', 'b_bar'])
+    component_c = DomainComponent('Component C', ['c_foo', 'c_bar', 'c_baz', 'c_bat'])
+
+    components = [component_a, component_b, component_c]
+
+    domain = Domain(components)
+    assert domain.components == components
+    assert domain.num_components == len(components)
+    assert domain.weights == [1 / len(components)] * len(components)
+
+
+def test_init_single_component():
+    component = DomainComponent('Component A', ['a_foo', 'a_bar', 'a_baz'])
+    components = [component]
+
+    domain = Domain(components)
+    assert domain.components == components
+    assert domain.num_components == len(components)
+    assert domain.weights == [1 / len(components)] * len(components)
+
+
+def test_init_no_components():
+    components = []
+
+    with pytest.raises(ValueError):
+        _ = Domain(components)
+
+
+def test_init_weight_component_shape_mismatch():
+    component_a = DomainComponent('Component A', ['a_foo', 'a_bar', 'a_baz'])
+    component_b = DomainComponent('Component B', ['b_foo', 'b_bar'])
+    component_c = DomainComponent('Component C', ['c_foo', 'c_bar', 'c_baz', 'c_bat'])
+
+    components = [component_a, component_b, component_c]
+    weights = [0.25, 0.75]
+
+    with pytest.raises(ValueError):
+        _ = Domain(components, weights)
+
+
+def test_init_from_dict():
+    component_dict = {
+        'Component A': {
+            'seed_words': ['a_foo', 'a_bar', 'a_baz'],
+            'description': 'A Mock Domain Component',
+            'weight': 1.5,
+        },
+        'Component B': {
+            'seed_words': ['b_foo', 'b_bar', 'b_baz'],
+            'description': 'B Mock Domain Component',
+            'weight': 0.7,
+        },
+        'Component C': {
+            'seed_words': ['c_foo', 'c_bar', 'c_baz'],
+            'description': 'C Mock Domain Component',
+            'weight': 0.3,
+        },
+    }
+
+    components, weights = [], []
+    for component_name, component_args in component_dict.items():
+        components.append(
+            DomainComponent(
+                component_name,
+                component_args['seed_words'],
+                component_args['description'],
+            )
+        )
+        weights.append(component_args['weight'])
+
+    domain = Domain.from_dict(component_dict)
+    assert domain.num_components == len(component_dict)
+    for component in domain.components:
+        assert component.name in component_dict
+        assert component_dict[component.name]['seed_words'] == component.seed_words
+        assert component_dict[component.name]['description'] == component.description
+    assert domain.weights == weights
+
+
+def test_init_from_dict_no_weights():
+    component_dict = {
+        'Component A': {
+            'seed_words': ['a_foo', 'a_bar', 'a_baz'],
+            'description': 'A Mock Domain Component',
+        },
+        'Component B': {
+            'seed_words': ['b_foo', 'b_bar', 'b_baz'],
+            'description': 'B Mock Domain Component',
+        },
+        'Component C': {
+            'seed_words': ['c_foo', 'c_bar', 'c_baz'],
+            'description': 'C Mock Domain Component',
+        },
+    }
+
+    domain = Domain.from_dict(component_dict)
+    assert domain.num_components == len(component_dict)
+    for component in domain.components:
+        assert component.name in component_dict
+        assert component_dict[component.name]['seed_words'] == component.seed_words
+        assert component_dict[component.name]['description'] == component.description
+    assert domain.weights == [1 / len(component_dict)] * len(component_dict)

--- a/test/test_domain.py
+++ b/test/test_domain.py
@@ -59,6 +59,17 @@ def test_init_weight_component_shape_mismatch():
         _ = Domain(components, weights)
 
 
+def test_init_negative_weight():
+    component_a = DomainComponent('Component A', ['a_foo', 'a_bar', 'a_baz'])
+    component_b = DomainComponent('Component B', ['b_foo', 'b_bar'])
+
+    components = [component_a, component_b]
+    weights = [0.25, -0.75]
+
+    with pytest.raises(ValueError):
+        _ = Domain(components, weights)
+
+
 def test_init_from_dict():
     component_dict = {
         'Component A': {

--- a/test/test_domain_component.py
+++ b/test/test_domain_component.py
@@ -67,3 +67,14 @@ def test_init_from_dict_missing_keys():
 
     with pytest.raises(ValueError):
         _ = DomainComponent.from_dict(component_dict)
+
+
+def test_init_to_dict():
+    component_dict = {
+        'name': 'TestComponent',
+        'seed_words': ['foo', 'bar', 'baz'],
+        'description': 'Mock Domain Component',
+    }
+
+    component = DomainComponent.from_dict(component_dict)
+    assert component_dict == component.to_dict()

--- a/test/test_domain_component.py
+++ b/test/test_domain_component.py
@@ -31,3 +31,39 @@ def test_init_empty_seed_words():
     seed_words = []
     with pytest.raises(ValueError):
         _ = DomainComponent(name, seed_words)
+
+
+def test_init_from_dict():
+    component_dict = {
+        'name': 'TestComponent',
+        'seed_words': ['foo', 'bar', 'baz'],
+        'description': 'Mock Domain Component',
+    }
+
+    component = DomainComponent.from_dict(component_dict)
+    assert component.name == component_dict['name']
+    assert component.seed_words == component_dict['seed_words']
+    assert component.description == component_dict['description']
+    assert component.num_seed_words == len(component_dict['seed_words'])
+
+
+def test_init_from_dict_no_description():
+    component_dict = {
+        'name': 'TestComponent',
+        'seed_words': ['foo', 'bar', 'baz'],
+    }
+
+    component = DomainComponent.from_dict(component_dict)
+    assert component.name == component_dict['name']
+    assert component.seed_words == component_dict['seed_words']
+    assert component.description is None
+    assert component.num_seed_words == len(component_dict['seed_words'])
+
+
+def test_init_from_dict_missing_keys():
+    component_dict = {  # Missing 'seed_words' key
+        'name': 'BadComponent',
+    }
+
+    with pytest.raises(ValueError):
+        _ = DomainComponent.from_dict(component_dict)

--- a/test/test_domain_component.py
+++ b/test/test_domain_component.py
@@ -1,0 +1,33 @@
+import pytest
+
+from aif_gen.task import DomainComponent
+
+
+def test_init():
+    name = 'TestComponent'
+    seed_words = ['foo', 'bar', 'baz']
+    description = 'Mock Domain Component'
+
+    component = DomainComponent(name, seed_words, description)
+    assert component.name == name
+    assert component.seed_words == seed_words
+    assert component.description == description
+    assert component.num_seed_words == len(seed_words)
+
+
+def test_init_no_description():
+    name = 'TestComponent'
+    seed_words = ['foo', 'bar', 'baz']
+
+    component = DomainComponent(name, seed_words)
+    assert component.name == name
+    assert component.seed_words == seed_words
+    assert component.description is None
+    assert component.num_seed_words == len(seed_words)
+
+
+def test_init_empty_seed_words():
+    name = 'BadComponent'
+    seed_words = []
+    with pytest.raises(ValueError):
+        _ = DomainComponent(name, seed_words)


### PR DESCRIPTION
### Purpose
The purpose of this PR is to add the `Domain` object, which itself is a (weighted) combination of `DomainComponents`. Each `DomainComponent` has a descriptive sed of _seed words_ that will be used to generate diverse synthetic samples.

### Relevant Issues
Stack #8 
Close #9 